### PR TITLE
Macro pass: no new macros needed

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -198,7 +198,7 @@ All code blocks are now disassembled into proper 6502 instructions:
 - [x] **Tail data annotation**: all sections labelled — build artifacts, ghost code, key/alias buffers, stored key defs, build scripts. Remaining EQUB is dead code with corrupt boundaries (ghost help handler) and structured data tables (OSFILE template, key_codes, NOOP macro).
 - [x] **Comment pass**: all routines documented across all 10 code files
 - [ ] **ZP workarounds**: 23 &00xx absolute addressing EQUB instructions (fix in improvements phase)
-- [ ] **Second macro pass**: find more repeated patterns after full annotation
+- [x] **Second macro pass**: reviewed — remaining patterns are standard 6502 idioms (16-bit pointer arithmetic, OSBYTE setup) that are better left explicit. Existing macros (STROUT, OP, NOOP, KW) cover the domain-specific patterns well.
 
 ## 2026-03-21: Label pass and absolute address elimination
 


### PR DESCRIPTION
Reviewed all repeated patterns across the codebase. The remaining ones
are standard 6502 idioms that are better left as explicit instructions:

- 16-bit pointer arithmetic (CLC/ADC lo/STA lo/LDA hi/ADC #0/STA hi)
- OSBYTE call setup (LDA/LDX/LDY)
- Branch chains (CMP/BNE)

These are instantly recognisable to anyone reading 6502 and hiding them
behind macros would obscure the actual CPU operations.

Existing macros cover the domain-specific patterns well:
- STROUT: print null-terminated string
- OP/NOOP: DIS opcode table entries
- KW: BASIC keyword table entries

This completes all TODO items for the reverse engineering phase.
Only remaining: ZP workarounds (improvements phase, binary changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)