### PR TITLE
Compact shift/carry/push pairs, fix remaining unnamed addresses

### DIFF
--- a/alias.asm
+++ b/alias.asm
@@ -40,8 +40,7 @@
         BNE skip_name
         INY
         LDA (zp_ptr_lo),Y
-        CLC
-        ADC zp_ptr_lo
+        CLC : ADC zp_ptr_lo
         STA zp_work_lo
         LDA zp_ptr_hi
         ADC #&00
@@ -73,8 +72,7 @@
         BNE find_loop
         INY
         LDA (zp_ptr_lo),Y
-        CLC
-        ADC zp_ptr_lo
+        CLC : ADC zp_ptr_lo
         STA zp_ptr_lo
         LDA zp_ptr_hi : ADC #&00 : STA zp_ptr_hi
         JMP check_end
@@ -90,10 +88,8 @@
         CMP #&0d
         BNE exec_copy
         TYA
-        SEC
-        SBC compare_string_y
-        CLC
-        ADC zp_ptr_lo
+        SEC : SBC compare_string_y
+        CLC : ADC zp_ptr_lo
         BCC exec_run
         LDA zp_ptr_hi
         CMP #&be
@@ -189,8 +185,7 @@
         BNE value
         INY
         TYA
-        CLC
-        ADC zp_ptr_lo
+        CLC : ADC zp_ptr_lo
         STA zp_ptr_lo
         LDA zp_ptr_hi : ADC #&00 : STA zp_ptr_hi
         JMP check
@@ -283,8 +278,7 @@
         JMP write_header
 \ %0-%9: Find the Nth space-delimited parameter from the original command line
 .get_param_num
-        SEC
-        SBC #'0'
+        SEC : SBC #'0'
         PHX
         TAX
         LDY compare_string_y
@@ -480,14 +474,12 @@
         BCC bad
         CMP #'G'
         BCS bad
-        SEC
-        SBC #'0'
+        SEC : SBC #'0'
         CMP #&0a
         BCC ok
         CMP #&11
         BCC bad
-        SEC
-        SBC #&07
+        SEC : SBC #&07
 .ok
         CLC
         RTS
@@ -512,16 +504,11 @@
         EQUS &EB, "Invalid hex digit", 0
 \ Shift existing value left by 4 bits and OR in the new digit
 .shift
-        ASL zp_src_lo
-        ROL zp_src_hi
-        ASL zp_src_lo
-        ROL zp_src_hi
-        ASL zp_src_lo
-        ROL zp_src_hi
-        ASL zp_src_lo
-        ROL zp_src_hi
-        CLC
-        ADC zp_src_lo
+        ASL zp_src_lo : ROL zp_src_hi
+        ASL zp_src_lo : ROL zp_src_hi
+        ASL zp_src_lo : ROL zp_src_hi
+        ASL zp_src_lo : ROL zp_src_hi
+        CLC : ADC zp_src_lo
         STA zp_src_lo
         LDA zp_src_hi
         ADC #&00

--- a/bau.asm
+++ b/bau.asm
@@ -98,15 +98,13 @@
         PHA
         SEC
         LDY #&03
-        SBC (&a8),Y
+        SBC (zp_ptr_lo),Y
         EOR #&ff
-        CLC
-        ADC #&04
+        CLC : ADC #&04
         STA zp_src_lo           \ new line length for the split-off portion
         PLA
         STA (zp_ptr_lo),Y
-        CLC
-        ADC zp_ptr_lo : STA zp_ptr_lo
+        CLC : ADC zp_ptr_lo : STA zp_ptr_lo
         LDA zp_ptr_hi : ADC #&00 : STA zp_ptr_hi
 \ Shift the program body upward by 3 bytes (room for new line header).
 \ Copies from TOP downward to avoid overwriting data.
@@ -145,8 +143,7 @@
 .next_line
         LDY #&03
         LDA (zp_ptr_lo),Y
-        CLC
-        ADC zp_ptr_lo : STA zp_ptr_lo
+        CLC : ADC zp_ptr_lo : STA zp_ptr_lo
         LDA zp_ptr_hi : ADC #&00 : STA zp_ptr_hi
         JMP line_loop
 
@@ -342,8 +339,7 @@
 .next_line
         LDY #&03
         LDA (zp_ptr_lo),Y
-        CLC
-        ADC zp_ptr_lo : STA zp_ptr_lo
+        CLC : ADC zp_ptr_lo : STA zp_ptr_lo
         LDA zp_ptr_hi : ADC #&00 : STA zp_ptr_hi
         JMP space_line_loop
 }
@@ -384,8 +380,7 @@
         LDA zp_ptr_hi
         PHA
         TYA
-        CLC
-        ADC zp_ptr_lo : STA zp_ptr_lo
+        CLC : ADC zp_ptr_lo : STA zp_ptr_lo
         LDA zp_ptr_hi : ADC #&00 : STA zp_ptr_hi
         LDA basic_lomem_lo : STA zp_tmp_lo
         LDA basic_lomem_hi : STA zp_tmp_hi

--- a/constants.asm
+++ b/constants.asm
@@ -50,6 +50,7 @@ basic_vartop_lo = &02           \ VARTOP low (end of variable heap)
 basic_vartop_hi = &03           \ VARTOP high
 basic_listo  = &1F              \ LISTO option (LIST formatting control)
 
+os_last_key  = &EC              \ OS copy of last key pressed
 os_escape_effect = &FF          \ Escape key effect flag (0 = normal escape)
 
 \ --- OS zero page ---

--- a/dis.asm
+++ b/dis.asm
@@ -181,8 +181,7 @@
     BNE dis_ascii_char
     JSR osnewl
     PLA
-    CLC
-    ADC zp_src_lo
+    CLC : ADC zp_src_lo
     STA zp_src_lo
     BCC dis_wait_key
     INC zp_src_hi
@@ -231,8 +230,7 @@
     STA zp_ptr_hi
     LDA (zp_src_lo),Y
     BMI dis_advance
-    CLC
-    ADC &a8
+    CLC : ADC zp_ptr_lo
     STA zp_ptr_lo
     LDA zp_ptr_hi
     ADC #&00
@@ -245,8 +243,7 @@
 \ Backward branch: offset is negative, so add &FF to the high byte
 \ (sign-extend the 8-bit negative offset to 16 bits).
 .dis_advance
-    CLC
-    ADC &a8
+    CLC : ADC zp_ptr_lo
     STA zp_ptr_lo
     LDA zp_ptr_hi
     ADC #&ff
@@ -263,16 +260,14 @@
         LDA #&08
         FOR n, 1, 5 : JSR oswrch : NEXT
         LDY #&01
-        LDA (&a8),Y
+        LDA (zp_ptr_lo),Y
         BMI rts
         STA dec_value_hi
         LDY #&02
-        LDA (&a8),Y : STA dec_value_lo
-        PHX
-        PHY
+        LDA (zp_ptr_lo),Y : STA dec_value_lo
+        PHX : PHY
         JSR print_decimal
-        PLY
-        PLX
+        PLY : PLX
 .rts
         RTS
 }

--- a/input.asm
+++ b/input.asm
@@ -294,8 +294,7 @@
 .do_delete
         LDA #&7f
         JSR oswrch
-        DEC xi_cursor_pos
-        DEC xi_line_len
+        DEC xi_cursor_pos : DEC xi_line_len
         LDY xi_cursor_pos
         PLA
         BEQ done
@@ -471,8 +470,7 @@
     SEC
     LDA os_win_right
     SBC os_win_left
-    CLC
-    ADC #&01
+    CLC : ADC #&01
     STA xi_char
     SEC
     LDA xi_cursor_pos
@@ -521,10 +519,8 @@
     SEC
     LDA os_win_right
     SBC os_win_left
-    CLC
-    ADC #&01
-    CLC
-    ADC xi_cursor_pos
+    CLC : ADC #&01
+    CLC : ADC xi_cursor_pos
     BCS xi_copy_down_truncate
     CMP xi_line_len
     BCS xi_copy_down_truncate
@@ -651,16 +647,14 @@
     BNE xi_htab_parse_loop
 \ Multiply the accumulated number by 10 and add the current digit.
 .xi_htab_mul10
-    ASL xi_char
-    ROL xi_temp
+    ASL xi_char : ROL xi_temp
     LDA xi_char
     ASL A
     STA zp_tmp_lo
     LDA xi_temp
     ROL A
     STA zp_tmp_hi
-    ASL zp_tmp_lo
-    ROL zp_tmp_hi
+    ASL zp_tmp_lo : ROL zp_tmp_hi
     CLC
     LDA xi_char
     ADC zp_tmp_lo
@@ -669,10 +663,8 @@
     ADC xi_temp
     STA xi_temp
     LDA (zp_ptr_lo),Y
-    SEC
-    SBC #'0'
-    CLC
-    ADC xi_char
+    SEC : SBC #'0'
+    CLC : ADC xi_char
     STA xi_char
     LDA xi_temp
     ADC #&00
@@ -704,8 +696,7 @@
     BNE xi_htab_advance_ptr
     INY
     LDA (zp_tmp_lo),Y
-    SEC
-    SBC #&04
+    SEC : SBC #&04
     TAX
     LDA #&00 : STA xi_quote_toggle
     LDA basic_listo
@@ -737,8 +728,7 @@
 .xi_htab_advance_ptr
     LDY #&03
     LDA (zp_tmp_lo),Y
-    CLC
-    ADC zp_tmp_lo
+    CLC : ADC zp_tmp_lo
     STA zp_tmp_lo
     LDA zp_tmp_hi
     ADC #&00
@@ -782,8 +772,7 @@
     INY
     INY
     TYA
-    CLC
-    ADC zp_src_lo
+    CLC : ADC zp_src_lo
     STA zp_src_lo
     LDA zp_src_hi
     ADC #&00

--- a/keys.asm
+++ b/keys.asm
@@ -106,7 +106,7 @@
     CPX #&40
     BNE kr_shift_1
 .kr_shift_ldx_0
-    LDX #&E1 : STX &EC
+    LDX #&E1 : STX os_last_key
 .kr_shift_orig_0
     LDX #&61
 .kr_shift_1
@@ -114,7 +114,7 @@
     CPX #&01
     BNE kr_shift_2
 .kr_shift_ldx_1
-    LDX #&C2 : STX &EC
+    LDX #&C2 : STX os_last_key
 .kr_shift_orig_1
     LDX #&42
 .kr_shift_2
@@ -122,7 +122,7 @@
     CPX #&48
     BNE kr_shift_3
 .kr_shift_ldx_2
-    LDX #&C8 : STX &EC
+    LDX #&C8 : STX os_last_key
 .kr_shift_orig_2
     LDX #&48
 .kr_shift_3
@@ -130,7 +130,7 @@
     CPX #&68
     BNE kr_shift_4
 .kr_shift_ldx_3
-    LDX #&E8 : STX &EC
+    LDX #&E8 : STX os_last_key
 .kr_shift_orig_3
     LDX #&68
 .kr_shift_4
@@ -138,7 +138,7 @@
     CPX #&49
     BNE kr_shift_done
 .kr_shift_ldx_4
-    LDX #&C9 : STX &EC
+    LDX #&C9 : STX os_last_key
 .kr_shift_orig_4
     LDX #&49
 .kr_shift_done
@@ -276,11 +276,11 @@
         TAY
         LDA (zp_ptr_lo),Y
 .search
-        LDX #&f1 : STX zp_ptr_lo
-        LDX #&8d : STX zp_ptr_hi
+        LDX #LO(key_name_table) : STX zp_ptr_lo
+        LDX #HI(key_name_table) : STX zp_ptr_hi
         LDY #&00
 .scan_loop
-        CMP (&a8),Y
+        CMP (zp_ptr_lo),Y
         BEQ found
         FOR n, 1, 10 : INY : NEXT  \ skip 10-byte entry (keycode + 9-char name)
         CPY #&96
@@ -422,8 +422,7 @@
         PLX
         STA key_codes,X
         DEC A
-        PHX
-        PHA
+        PHX : PHA
         JSR keyname_lookup
         JSR osnewl
         PLA
@@ -438,8 +437,7 @@
         JSR osbyte
         CPX #&ff
         BEQ next_entry
-        PLX
-        PLX
+        PLX : PLX
         RTS
 }
 \ Skip spaces and dots in the command line, leaving Y pointing at the

--- a/lvar.asm
+++ b/lvar.asm
@@ -26,8 +26,7 @@
 .check_type
         TXA
         LSR A                   \ bucket index / 2
-        CLC
-        ADC #'@'                \ convert to ASCII letter ('A' onwards)
+        CLC : ADC #'@'          \ convert to ASCII letter ('A' onwards)
         JSR oswrch
         LDY #&01
 .skip_name
@@ -234,35 +233,35 @@
 .inc_cursor
         INC xi_line_len
         SEC
-        LDA &AC
+        LDA zp_tmp_lo
         SBC xi_line_len
-        STA &AE
-        LDA &AD
+        STA zp_src_lo
+        LDA zp_tmp_hi
         SBC #&00
-        STA &AF
+        STA zp_src_hi
         DEC xi_line_len
         LDA #&0d : STA xi_hist_term
         LDA #&ff : STA xi_hist_flag
 .copy_loop
         LDA (zp_src_lo) : STA (zp_tmp_lo)
         SEC
-        LDA &AC
+        LDA zp_tmp_lo
         SBC #&01
-        STA &AC
-        LDA &AD
+        STA zp_tmp_lo
+        LDA zp_tmp_hi
         SBC #&00
-        STA &AD
+        STA zp_tmp_hi
         SEC
-        LDA &AE
+        LDA zp_src_lo
         SBC #&01
-        STA &AE
-        LDA &AF
+        STA zp_src_lo
+        LDA zp_src_hi
         SBC #&00
-        STA &AF
-        LDA &AE
+        STA zp_src_hi
+        LDA zp_src_lo
         CMP #&54
         BNE copy_loop
-        LDA &AF
+        LDA zp_src_hi
         CMP #zp_work_lo
         BNE copy_loop
         LDY xi_line_len
@@ -331,17 +330,16 @@
 .advance
         INY
         TYA
-        CLC
-        ADC &AE
-        STA &AE
-        LDA &AF
+        CLC : ADC zp_src_lo
+        STA zp_src_lo
+        LDA zp_src_hi
         ADC #&00
-        STA &AF
+        STA zp_src_hi
         DEX
         BEQ clear_and_load
         CMP #zp_src_lo
         BCC check_end
-        LDA &AE
+        LDA zp_src_lo
         CMP #&55
         BCC check_end
         LDA #&00 : STA xi_scroll_count
@@ -395,8 +393,7 @@
         LDX #&10                \ 16 bits to shift
         LDA #&00
 .shift
-        ASL dec_value_lo
-        ROL dec_value_hi
+        ASL dec_value_lo : ROL dec_value_hi
         ROL A                   \ shift next bit into accumulator
         CMP #&0a
         BCC next_bit
@@ -405,8 +402,7 @@
 .next_bit
         DEX
         BNE shift
-        CLC
-        ADC #'0'                \ convert digit to ASCII
+        CLC : ADC #'0'          \ convert digit to ASCII
         PHA                     \ push digit (most significant first)
         INY
         LDA dec_value_lo

--- a/mem.asm
+++ b/mem.asm
@@ -26,7 +26,7 @@
         LDA zp_ptr_lo
         AND #&07
         STA mem_column
-        EOR &a8
+        EOR zp_ptr_lo
         STA zp_ptr_lo
         LDA #&16
         JSR oswrch
@@ -161,12 +161,12 @@
         BPL mem_cursor_rts
         LDA #&07 : STA mem_column
         SEC
-        LDA &A8
+        LDA zp_ptr_lo
         SBC #&08
-        STA &A8
-        LDA &A9
+        STA zp_ptr_lo
+        LDA zp_ptr_hi
         SBC #&00
-        STA &A9
+        STA zp_ptr_hi
 }
 .mem_cursor_rts
     RTS
@@ -200,21 +200,21 @@
         CPX #&ff
         BNE row_up
         SEC
-        LDA &A8
+        LDA zp_ptr_lo
         SBC #&b0
-        STA &A8
-        LDA &A9
+        STA zp_ptr_lo
+        LDA zp_ptr_hi
         SBC #&00
-        STA &A9
+        STA zp_ptr_hi
         RTS
 .row_up
         SEC
-        LDA &A8
+        LDA zp_ptr_lo
         SBC #&08
-        STA &A8
-        LDA &A9
+        STA zp_ptr_lo
+        LDA zp_ptr_hi
         SBC #&00
-        STA &A9
+        STA zp_ptr_hi
         RTS
 }
 \ Page down: if SHIFT is held, jump forward by a full page (&B0 bytes);
@@ -228,21 +228,21 @@
         CPX #&ff
         BNE row_down
         CLC
-        LDA &A8
+        LDA zp_ptr_lo
         ADC #&b0
-        STA &A8
-        LDA &A9
+        STA zp_ptr_lo
+        LDA zp_ptr_hi
         ADC #&00
-        STA &A9
+        STA zp_ptr_hi
         RTS
 .row_down
         CLC
-        LDA &A8
+        LDA zp_ptr_lo
         ADC #&08
-        STA &A8
-        LDA &A9
+        STA zp_ptr_lo
+        LDA zp_ptr_hi
         ADC #&00
-        STA &A9
+        STA zp_ptr_hi
         RTS
 }
 \ Toggle between hex-entry ('H') and ASCII-entry ('A') mode by flipping

--- a/xmos.asm
+++ b/xmos.asm
@@ -216,8 +216,7 @@ GUARD &C000
         CMP #&00
         BNE print_name_2
         TYA                     \ Pad with spaces to column 11
-        SEC
-        SBC #&09
+        SEC : SBC #&09
         EOR #&FF : INC A        \ negate
         TAX
 .pad_loop_2
@@ -269,8 +268,7 @@ GUARD &C000
         BNE skip_help
         INY                     \ Advance past help text null terminator
         TYA
-        CLC
-        ADC zp_ptr_lo
+        CLC : ADC zp_ptr_lo
         STA zp_ptr_lo
         LDA zp_ptr_hi
         ADC #&00


### PR DESCRIPTION
## Summary
Compact ASL/ROL, CLC/ADC, SEC/SBC, and push/pull pairs onto single lines per STYLE.md. Also fix unnamed hex addresses that were missed in PR #28.

## Instruction compaction
- ASL/ROL shift pairs → `ASL lo : ROL hi` (alias, input, lvar)
- CLC/ADC, SEC/SBC carry pairs compacted across all files
- Push/pull pairs: `PHX : PHY`, `PLY : PLX`, etc. (dis, keys)
- DEC pair: `DEC xi_cursor_pos : DEC xi_line_len` (input)

## Unnamed addresses fixed
Missed in the previous PR:
- &A8/&A9 → zp_ptr_lo/hi in mem, bau, keys
- &AC/&AD/&AF → zp_tmp/src in lvar
- &EC → os_last_key (new constant) in keys
- &8DF1 → LO/HI(key_name_table) in keys

Comprehensive audit confirms zero unnamed hex addresses remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)