### PR TITLE
Fix hardcoded defkeys_direction_labels address

### DIFF
--- a/keys.asm
+++ b/keys.asm
@@ -317,8 +317,8 @@
         LDA keyon_active
         BEQ kstatus_not_active
         STROUT msg_keys_on
-        LDA #&d0 : STA zp_work_lo
-        LDA #&8e : STA zp_work_hi
+        LDA #LO(defkeys_direction_labels) : STA zp_work_lo
+        LDA #HI(defkeys_direction_labels) : STA zp_work_hi
         LDX #&00
 .loop
         LDY #&00
@@ -371,8 +371,8 @@
         JSR osnewl
         STROUT msg_key_redefiner
         JSR osnewl
-        LDA #&d0 : STA zp_work_lo
-        LDA #&8e : STA zp_work_hi
+        LDA #LO(defkeys_direction_labels) : STA zp_work_lo
+        LDA #HI(defkeys_direction_labels) : STA zp_work_hi
         LDX #&00
 .header_y
         LDY #&00


### PR DESCRIPTION
## Summary
*KSTATUS and *DEFKEYS used hardcoded `&8ED0` for the direction label table pointer. Replace with `LO/HI(defkeys_direction_labels)` so the address tracks if code changes shift the table.

This is a latent bug — currently the address happens to be correct, but any code change upstream (e.g. in input.asm) would shift the table and cause *DEFKEYS to crash and *KSTATUS to display garbage.

## Test plan
- [x] All 80 tests pass — no behavior change at current addresses

🤖 Generated with [Claude Code](https://claude.com/claude-code)