### PR TITLE
Use andy constant for ANDY addresses; rename alias expansion buffer

### DIFF
--- a/alias.asm
+++ b/alias.asm
@@ -236,7 +236,7 @@
 .cmd_done
         PLY : PLX : PLA
         RTS
-\ Alias matched — expand it with parameter substitution into store_buf_3.
+\ Alias matched — expand it with parameter substitution into alias_expand_buf.
 \ The expanded text becomes the argument to *KEY 0, which is then triggered
 \ to type it at the prompt (see .open below).
 .exec_entry
@@ -257,7 +257,7 @@
         LDA (zp_ptr_lo),Y
         INY
         STY alias_file_handle
-        STA store_buf_3,X
+        STA alias_expand_buf,X
         INX
         CMP #&0d
         BNE check_percent
@@ -306,7 +306,7 @@
         CMP #&0d
         BEQ next_expand
         BEQ next_expand
-        STA store_buf_3,X
+        STA alias_expand_buf,X
         INX
         INY
         BNE copy_param_loop
@@ -433,10 +433,10 @@
         STA rom_number : STA sheila_romsel
         LDX #&00
 .copy_loop
-        LDA &8000,X : STA store_buf_0,X
-        LDA &8100,X : STA store_buf_1,X
-        LDA &8200,X : STA store_buf_2,X
-        LDA &8300,X : STA alias_exec_buf,X
+        LDA andy+&000,X : STA store_buf+&000,X
+        LDA andy+&100,X : STA store_buf+&100,X
+        LDA andy+&200,X : STA store_buf+&200,X
+        LDA andy+&300,X : STA alias_exec_buf,X
         INX
         BNE copy_loop
         LDA sheila_romsel : AND #&7f : STA rom_number : STA sheila_romsel
@@ -456,9 +456,9 @@
         STA rom_number : STA sheila_romsel
         LDX #&00
 .restore_loop
-        LDA store_buf_0,X : STA &8000,X
-        LDA store_buf_1,X : STA &8100,X
-        LDA store_buf_2,X : STA &8200,X
+        LDA store_buf+&000,X : STA andy+&000,X
+        LDA store_buf+&100,X : STA andy+&100,X
+        LDA store_buf+&200,X : STA andy+&200,X
         INX
         BNE restore_loop
         LDA sheila_romsel : AND #&7f : STA rom_number : STA sheila_romsel

--- a/basic.asm
+++ b/basic.asm
@@ -59,21 +59,17 @@
 \ the incore filename pointer, PAGE (load/start), and TOP (end).
 \ ---
 .osfile_block
-    EQUB &07, &30               \ +0: Filename pointer (overwritten)
-    EQUB &00, &30               \ +2: Load address low/high (high overwritten with PAGE)
-    EQUB &ff, &ff               \ +4: Load address top word (&FFFF = host)
-    EQUB &2B, &80               \ +6: Exec address low/high
-    EQUB &ff, &ff               \ +8: Exec address top word (&FFFF = host)
-    EQUB &AC, &05               \ +10: Start address (overwritten)
-    EQUB &00, &00               \ +12: Start address top
-    EQUB &00, &00               \ +14: End address (overwritten with TOP)
-    EQUB &00, &00               \ +16: End address top
+    SKIP 18                     \ Overwritten from osfile_template on each call
 .osfile_template                \ Template copied into osfile_block on each call
-    EQUB &00, &00, &00, &00     \ Filename/load addr (zeroed)
-    EQUB &ff, &ff, &2B, &80     \ Load addr top + exec addr
-    EQUB &ff, &ff, &00, &00     \ Exec addr top + start addr
-    EQUB &ff, &ff, &00, &00     \ Start addr top + end addr
-    EQUB &ff, &ff               \ End addr top
+    EQUW &0000                  \ +0: Filename pointer (patched later)
+    EQUW &0000                  \ +2: Load address low (patched with PAGE)
+    EQUW &ffff                  \ +4: Load address high (&FFFF = host)
+    EQUW &802b                  \ +6: Exec address low (ROM entry point)
+    EQUW &ffff                  \ +8: Exec address high (&FFFF = host)
+    EQUW &0000                  \ +10: Start address low (patched with PAGE)
+    EQUW &ffff                  \ +12: Start address high (&FFFF = host)
+    EQUW &0000                  \ +14: End address low (patched with TOP)
+    EQUW &ffff                  \ +16: End address high (&FFFF = host)
 
 \ ============================================================================
 \ find_incore_name — Locate the embedded filename in the BASIC program.

--- a/constants.asm
+++ b/constants.asm
@@ -23,6 +23,7 @@ osrdrm       = &FFB9
 
 \ --- Hardware registers ---
 sheila_romsel = &FE30           \ ROM select latch
+andy         = &8000            \ 4K private RAM (ROMSEL bit 7)
 
 \ --- Service call numbers ---
 svc_command  = &04              \ Unrecognised * command

--- a/data.asm
+++ b/data.asm
@@ -303,11 +303,9 @@
 \ ============================================================================
 .workspace_start
 .alias_oscli_buf EQUS "KEY9 "   \ Required: *KEY 9 prefix for alias expansion
-.store_buf_3    SKIP 250        \ Alias expansion text / *STORE buffer: ANDY page 3
-.store_buf_0    SKIP 256        \ *STORE buffer: ANDY page 0 (&8000-&80FF)
-.store_buf_1    SKIP 256        \ *STORE buffer: ANDY page 1 (&8100-&81FF)
-.store_buf_2    SKIP 256        \ *STORE buffer: ANDY page 2 (&8200-&82FF)
-.alias_exec_buf SKIP 256        \ *STORE buffer: ANDY page 3 (&8300-&83FF)
+.alias_expand_buf SKIP 250      \ Alias expansion text (follows alias_oscli_buf for OSCLI)
+.store_buf      SKIP 768        \ *STORE: saves ANDY &8000-&82FF, restored by alias_init
+.alias_exec_buf SKIP 256        \ *STORE saves ANDY page 3 here (not restored)
 .alias_buffer                   \ Alias expansion buffer (shares xi_hist_buffer)
 .xi_hist_buffer SKIP 1022       \ Command history buffer
 .xi_hist_term   SKIP 1          \ Set to &0D at runtime

--- a/lvar.asm
+++ b/lvar.asm
@@ -52,23 +52,15 @@
         BNE var_loop
         RTS
 }
-\ --- MEM editor configuration data ---
-.mem_workspace
-    EQUB &00, &00
-.mem_edit_lo
-    EQUB &00
-.mem_edit_hi
-    EQUB &12
-.mem_vdu_1
-    EQUB &E3
-.mem_vdu_2
-    EQUB &16
-.mem_mode
-    EQUB &01
-.mem_page_size
-    EQUB &03
-.mem_column
-    EQUB &02                    \ MEM column counter (0-7)
+\ --- MEM/DIS editor workspace (all set at runtime) ---
+.mem_workspace  SKIP 2
+.mem_edit_lo    SKIP 1          \ MEM current address low byte
+.mem_edit_hi    SKIP 1          \ MEM current address high byte
+.mem_vdu_1      SKIP 1          \ DIS resume address low byte
+.mem_vdu_2      SKIP 1          \ DIS resume address high byte
+.mem_mode       SKIP 1          \ Saved WRCH destination during MEM
+.mem_page_size  SKIP 1          \ Saved screen pages during MEM
+.mem_column     SKIP 1          \ MEM column counter (0-7)
 .mem_key_codes
     EQUB &88, &89, &8A, &8B     \ Key codes: left, right, down, up
     EQUB &09                    \ TAB key


### PR DESCRIPTION
## Summary

### ANDY constant
- Add `andy = &8000` constant for ANDY private RAM
- Replace hardcoded `&8000`/`&8100`/`&8200`/`&8300` in `cmd_store` and `alias_init` with `andy+&000` etc.

### Store buffer consolidation
- Consolidate `store_buf_0`/`store_buf_1`/`store_buf_2` into single `store_buf` (768 bytes)
- Referenced as `store_buf+&000`/`+&100`/`+&200` to mirror the `andy+&xxx` pattern
- Makes the asymmetric save/restore (#43) obvious

### Rename alias expansion buffer
- Rename `store_buf_3` to `alias_expand_buf` — the alias expansion text buffer that follows `alias_oscli_buf` for the OSCLI call, not related to `*STORE`

### OSFILE parameter block cleanup
- Convert `osfile_block` to SKIP 18 (runtime workspace, overwritten from template on each `*S` call)
- Convert `osfile_template` EQUB pairs to EQUW with meaningful comments (`&802B` = ROM entry point, `&FFFF` = host marker)

### MEM/DIS workspace cleanup
- Convert `mem_workspace`, `mem_edit_lo`/`hi`, `mem_vdu_1`/`2`, `mem_mode`, `mem_page_size`, `mem_column` from EQUB (captured runtime state) to SKIP (all set at runtime)

## Test plan
- [x] All 81 tests pass (including *S save tests and *DIS/*MEM tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)