### PR TITLE
Remove unreachable "Missing" KW entry; add explicit alias sentinel

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -406,11 +406,9 @@ it fires when the line IS empty.
 1. **ROMSEL not restored on XON-disabled path**: when XON is off,
    `xi_check_xon` JMPs to the default KEYV handler without returning
    through the ROMSEL cleanup code. Rich noted this as a bug.
-2. ~~**Dead code in COPY handler**~~: originally thought the BEQ
-   at xi_copy_down_truncate was dead. On analysis (2026-03-29),
-   it IS reachable — handles cursor_pos == line_len (cursor at
-   end of line). The preceding CMP checks (window_width +
-   cursor_pos) vs line_len, which is a different comparison.
+2. **Dead code in COPY handler**: the BEQ after the second
+   length-cursor subtraction can never fire because equality was
+   already handled by the preceding CMP/BEQ.
 3. **Ctrl-N/Ctrl-O double-echo**: these fall through to
    xi_handle_printable which echoes them again.
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -406,9 +406,11 @@ it fires when the line IS empty.
 1. **ROMSEL not restored on XON-disabled path**: when XON is off,
    `xi_check_xon` JMPs to the default KEYV handler without returning
    through the ROMSEL cleanup code. Rich noted this as a bug.
-2. **Dead code in COPY handler**: the BEQ after the second
-   length-cursor subtraction can never fire because equality was
-   already handled by the preceding CMP/BEQ.
+2. ~~**Dead code in COPY handler**~~: originally thought the BEQ
+   at xi_copy_down_truncate was dead. On analysis (2026-03-29),
+   it IS reachable — handles cursor_pos == line_len (cursor at
+   end of line). The preceding CMP checks (window_width +
+   cursor_pos) vs line_len, which is a different comparison.
 3. **Ctrl-N/Ctrl-O double-echo**: these fall through to
    xi_handle_printable which echoes them again.
 
@@ -600,14 +602,25 @@ causes the scan to run past the table end, but the outer byte
 counter prevents visible damage.
 
 "Missing" (token &FF, flags &4F) is unreachable — token &FF
-matches "OSCLI" earlier in the table. It exists to provide the
-&FF byte used as the initial alias table sentinel. Could be
-removed (saving 9 bytes) with a separate sentinel byte.
+matches "OSCLI" earlier in the table. It existed to provide the
+&FF byte used as the initial alias table sentinel.
+
+### "Missing" KW entry removed — DONE
+Removed the unreachable "Missing" entry (9 bytes) and replaced
+with an explicit `EQUB &FF` alias table sentinel. The keyword
+table scan still has no end-of-table check (token &8D has no
+entry), but the outer byte counter prevents visible damage.
 
 ### Remaining
-- Remove "Missing" KW entry and add explicit alias table sentinel (#47)
-- Remove COPY handler dead code (needs analysis — may not be dead)
-- OSBYTE 4 dedup: 4 inline instances, saves 12 bytes but reduces readability
+- ~~Remove COPY handler dead code~~ — NOT dead: the BEQ at
+  xi_copy_down_truncate handles cursor at end of line (cursor_pos
+  == line_len). The journal note was wrong — the preceding CMP
+  checks (window_width + cursor_pos) vs line_len, a different
+  comparison.
+- OSBYTE 4 dedup: 6 instances (4 enable, 2 disable), all in ROM-
+  resident code (not workspace). A shared routine saves 11 bytes
+  net. Marginal — the inline pattern is self-documenting and 11
+  bytes is negligible in a 16KB ROM with ~6.8KB free.
 
 ### jsbeeb TestMachine (done in 1.9.1)
 - [x] Case-correct type() via CAPS LOCK detection

--- a/data.asm
+++ b/data.asm
@@ -436,7 +436,6 @@
     KW "TIME", &d1, &00
     KW "LOMEM", &d2, &00
     KW "HIMEM", &d3, &00
-    EQUS "Missing"              \ Unreachable KW entry (token &FF matches OSCLI first)
 .alias_table                    \ Start of alias table; &FF = empty sentinel
-    EQUB &ff, &4f
+    EQUB &ff
 


### PR DESCRIPTION
Remove the "Missing" keyword table entry (token &FF, flags &4F) and replace with an explicit EQUB &FF alias table sentinel. Saves 9 bytes.

"Missing" was unreachable — the keyword table scan (xi_htab) is linear, and token &FF matches "OSCLI" (earlier in the table) before reaching "Missing". The entry existed only to provide the &FF byte that serves as the empty alias table sentinel.

The keyword table scan still has no end-of-table check (token &8D / line number reference has no entry), but the outer TAB-expansion byte counter prevents visible damage.

Also updates journal with COPY handler analysis (BEQ is NOT dead — handles cursor at end of line) and OSBYTE 4 dedup analysis (marginal, 11 bytes net saving).

Fixes #47.

## Test plan
- [x] All 82 tests pass (including LVAR-after-alias)

Generated with Claude Code